### PR TITLE
Recovery changes

### DIFF
--- a/contrib/src/main/java/com/datatorrent/contrib/hdht/HDHTReader.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/hdht/HDHTReader.java
@@ -368,6 +368,7 @@ public class HDHTReader implements Operator, HDHT.Reader
     int fileSeq;
     long committedWid;
     final TreeMap<Slice, BucketFileMeta> files;
+    HDHTWalManager.WalPosition recoveryStartWalPosition;
   }
 
   private static class BucketReader implements Closeable

--- a/contrib/src/test/java/com/datatorrent/contrib/hdht/MockFileAccess.java
+++ b/contrib/src/test/java/com/datatorrent/contrib/hdht/MockFileAccess.java
@@ -46,6 +46,10 @@ public class MockFileAccess extends HDHTFileAccessFSImpl
 
   private final Set<String> deletedFiles = Sets.newHashSet();
 
+  public void disableChecksum() {
+    fs.setVerifyChecksum(false);
+  }
+
   @Override
   public void delete(long bucketKey, String fileName) throws IOException
   {


### PR DESCRIPTION
Fix wal recovery test case.
Remove unused variables and some code cleanup.
Save wal positions for checkpointed window.
Save wal recovery start position in bucket metadata instead of operator checkpoint, recovery end position is saved in operator checkpoint.