### PR TITLE
SPOI-3861 #comment Fixing Pi demo memory and performance settings

### DIFF
--- a/demos/pi/src/main/resources/META-INF/properties.xml
+++ b/demos/pi/src/main/resources/META-INF/properties.xml
@@ -1,47 +1,68 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <configuration>
-<!--properties for pi demo  -->
+  <!-- Memory settings for all demos -->
   <property>
     <name>dt.attr.MASTER_MEMORY_MB</name>
     <value>1024</value>
   </property>
-<property>
-	<name>dt.application.PiDemo.operator.rand.minvalue</name>
-	<value>0</value>
-</property>
-<property>
-	<name>dt.application.PiDemo.operator.rand.maxvalue</name>
-	<value>30000</value>
-</property>
-<property>
-	<name>dt.application.PiDemo.operator.picalc.base</name>
-	<value>900000000</value>
-</property>
-<property>
-	<name>dt.application.PiDemo.operator.*.attr.MEMORY_MB</name>
-	<value>512</value>
-</property>
-<!-- prperties for pi library demo -->
-<property>
-	<name>dt.application.PiLibraryDemo.operator.GenerateX.minvalue</name>
-	<value>0</value>
-</property>
-<property>
-	<name>dt.application.PiLibraryDemo.operator.GenerateX.maxvalue</name>
-	<value>30000</value>
-</property>
-<property>
-	<name>dt.application.PiLibraryDemo.operator.PairXY.size</name>
-	<value>2</value>
-</property>
-<property>
-	<name>dt.application.PiLibraryDemo.operator.*.attr.MEMORY_MB</name>
-	<value>512</value>
-</property>
-<!--
-<property>
-	<name>dt.application.PiLibraryDemo.operator.AnalyzeLocation.constant</name>
-	<value>900000000</value>
-</property> -->
+  <property>
+    <name>dt.operator.rand.attr.MEMORY_MB</name>
+    <value>256</value>
+  </property>
+  <property>
+    <name>dt.port.integer_data.attr.BUFFER_MEMORY_MB</name>
+    <value>384</value>
+  </property>
+  <property>
+    <name>dt.operator.*.attr.MEMORY_MB</name>
+    <value>128</value>
+  </property>
+  <property>
+    <name>dt.port.*.attr.BUFFER_MEMORY_MB</name>
+    <value>256</value>
+  </property>
+
+  <!-- PiDemo  -->
+  <property>
+    <name>dt.application.PiDemo.operator.rand.minvalue</name>
+    <value>0</value>
+  </property>
+  <property>
+    <name>dt.application.PiDemo.operator.rand.maxvalue</name>
+    <value>30000</value>
+  </property>
+  <property>
+    <name>dt.application.PiDemo.operator.picalc.base</name>
+    <value>900000000</value>
+  </property>
+
+  <!-- PiLibraryDemo -->
+  <property>
+    <name>dt.application.PiLibraryDemo.operator.GenerateX.minvalue</name>
+    <value>0</value>
+  </property>
+  <property>
+    <name>dt.application.PiLibraryDemo.operator.GenerateX.maxvalue</name>
+    <value>30000</value>
+  </property>
+  <property>
+    <name>dt.application.PiLibraryDemo.operator.PairXY.size</name>
+    <value>2</value>
+  </property>
+  <!-- <property>
+    <name>dt.application.PiLibraryDemo.operator.AnalyzeLocation.constant</name>
+    <value>900000000</value>
+  </property> -->
+
+  <!-- PiJavaScriptDemo -->
+  <property>
+    <name>dt.application.PiJavaScriptDemo.operator.rand.tuplesBlast</name>
+    <value>9</value>
+  </property>
+  <property>
+    <name>dt.application.PiJavaScriptDemo.operator.picalc.attr.MEMORY_MB</name>
+    <value>384</value>
+  </property>
+
 
 </configuration>


### PR DESCRIPTION
Fixing:

* Memory settings required for all Pi demos
* Random generator tuplesBlast for PiJavaScriptDemo to balance speed of generation and processing in the app DAG