### PR TITLE
SPOI-4008 #resolve

### DIFF
--- a/contrib/src/main/java/com/datatorrent/contrib/hdht/HDHTWriter.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/hdht/HDHTWriter.java
@@ -511,11 +511,10 @@ public class HDHTWriter extends HDHTReader implements CheckpointListener, Operat
         }
       }
 
-      HDHTWalManager.WalPosition position = null;
       for (Iterator<Map.Entry<Long, HDHTWalManager.WalPosition>> wpIter = bucket.walPositions.entrySet().iterator(); wpIter.hasNext();) {
         Map.Entry<Long, HDHTWalManager.WalPosition> entry = wpIter.next();
         if (entry.getKey() <= committedWindowId) {
-          position = entry.getValue();
+          bucket.recoveryStartWalPosition = entry.getValue();
           wpIter.remove();
         }
       }
@@ -524,13 +523,11 @@ public class HDHTWriter extends HDHTReader implements CheckpointListener, Operat
         // ensure previous flush completed
         if (bucket.frozenWriteCache.isEmpty()) {
           bucket.frozenWriteCache = bucket.committedWriteCache;
+          bucket.committedWriteCache = Maps.newHashMap();
 
           bucket.committedLSN = committedWindowId;
-          bucket.recoveryStartWalPosition = position;
 
-
-          bucket.committedWriteCache = Maps.newHashMap();
-          LOG.debug("Flushing data for bucket {} committedWid {}", bucket.bucketKey, bucket.committedLSN);
+          LOG.debug("Flushing data for bucket {} committedWid {} recoveryStartWalPosition {}", bucket.bucketKey, bucket.committedLSN, bucket.recoveryStartWalPosition);
           Runnable flushRunnable = new Runnable() {
             @Override
             public void run()


### PR DESCRIPTION
Handle case where no data is added to HDHT between two committed
callbacks, and flush was triggered because of flush interval.