### PR TITLE
SPOI-4183: proposal to change basic counters

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/counters/AggregateMethod.java
+++ b/library/src/main/java/com/datatorrent/lib/counters/AggregateMethod.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2015 DataTorrent, Inc. ALL Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.lib.counters;
+
+public interface AggregateMethod
+{
+  String getName();
+
+  Number aggregate(NumberCounter... numbersCounters);
+
+  public static class SumAggregateMethod implements AggregateMethod
+  {
+
+    @Override
+    public String getName()
+    {
+      return "sum";
+    }
+
+    @Override
+    public Number aggregate(NumberCounter... numbersCounters)
+    {
+      if (numbersCounters.length == 0) {
+        return null;
+      }
+      long longResult = 0;
+      double doubleResult = 0;
+      for (NumberCounter nc : numbersCounters) {
+        Number no = nc.getNumberValue();
+        if (no instanceof Integer || no instanceof Long) {
+          longResult += no.longValue();
+        }
+        else {
+          doubleResult += no.doubleValue();
+        }
+      }
+      if (doubleResult == 0) {
+        return longResult;
+      }
+      return doubleResult + longResult;
+    }
+  }
+
+  public static class MinAggregateMethod implements AggregateMethod
+  {
+
+    @Override
+    public String getName()
+    {
+      return "min";
+    }
+
+    @Override
+    public Number aggregate(NumberCounter... numbersCounters)
+    {
+      if (numbersCounters.length == 0) {
+        return null;
+      }
+
+      Number min = numbersCounters[0].getNumberValue();
+      for (int i = 1; i < numbersCounters.length; i++) {
+        Number no = numbersCounters[i].getNumberValue();
+        if ((min instanceof Integer || min instanceof Long) && (no instanceof Integer || no instanceof Long)) {
+
+          min = Math.min(no.longValue(), min.longValue());
+        }
+        else {
+          min = Math.min(no.doubleValue(), min.doubleValue());
+
+        }
+      }
+      return min;
+    }
+
+  }
+
+  public static class MaxAggregateMethod implements AggregateMethod
+  {
+
+    @Override
+    public String getName()
+    {
+      return "max";
+    }
+
+    @Override
+    public Number aggregate(NumberCounter... numbersCounters)
+    {
+      if (numbersCounters.length == 0) {
+        return null;
+      }
+
+      Number max = numbersCounters[0].getNumberValue();
+      for (int i = 1; i < numbersCounters.length; i++) {
+        Number no = numbersCounters[i].getNumberValue();
+        if ((max instanceof Integer || max instanceof Long) && (no instanceof Integer || no instanceof Long)) {
+
+          max = Math.max(no.longValue(), max.longValue());
+        }
+        else {
+          max = Math.max(no.doubleValue(), max.doubleValue());
+
+        }
+      }
+      return max;
+    }
+  }
+
+  public static class AvgAggregateMethod implements AggregateMethod
+  {
+
+    @Override
+    public String getName()
+    {
+      return "avg";
+    }
+
+    @Override
+    public Number aggregate(NumberCounter... numbersCounters)
+    {
+      if (numbersCounters.length == 0) {
+        return null;
+      }
+      long longResult = 0;
+      double doubleResult = 0;
+
+      for (NumberCounter nc : numbersCounters) {
+        Number no = nc.getNumberValue();
+        if (no instanceof Integer || no instanceof Long) {
+          longResult += no.longValue();
+        }
+        else {
+          doubleResult += no.doubleValue();
+        }
+      }
+      if (doubleResult == 0) {
+        return (longResult * 1.0) / numbersCounters.length;
+      }
+      return (doubleResult + longResult) / numbersCounters.length;
+    }
+  }
+}

--- a/library/src/main/java/com/datatorrent/lib/counters/BasicCounters.java
+++ b/library/src/main/java/com/datatorrent/lib/counters/BasicCounters.java
@@ -37,9 +37,11 @@ import com.datatorrent.lib.util.NumberAggregate;
 /**
  * Implementation of basic number counters.
  *
+ * @deprecated use {@link Counters}
  * @param <T> type of counter
  * @since 1.0.2
  */
+@Deprecated
 @JsonSerialize(using = BasicCounters.Serializer.class)
 public class BasicCounters<T extends Number & Mutable> implements Serializable
 {

--- a/library/src/main/java/com/datatorrent/lib/counters/Counters.java
+++ b/library/src/main/java/com/datatorrent/lib/counters/Counters.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2014 DataTorrent, Inc. ALL Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.lib.counters;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.SerializerProvider;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import com.datatorrent.api.Context;
+
+/**
+ * Collection of {@link NumberCounter}
+ */
+@JsonSerialize(using = Counters.Serializer.class)
+public class Counters
+{
+  private final Map<String, NumberCounter> cache;
+
+  public Counters()
+  {
+    cache = Maps.newHashMap();
+  }
+
+  /**
+   * Returns the counter if it exists; null otherwise
+   *
+   * @param counterKey
+   * @return counter corresponding to the counter key.
+   */
+  public synchronized NumberCounter getCounter(String counterKey)
+  {
+    return cache.get(counterKey);
+  }
+
+  /**
+   * Sets the value of a counter.
+   *
+   * @param counterKey counter key.
+   * @param value      new value.
+   */
+  public synchronized void setCounter(String counterKey, NumberCounter value)
+  {
+    cache.put(counterKey, value);
+  }
+
+  /**
+   * Returns an immutable copy of all the counters.
+   *
+   * @return an immutable copy of the counters.
+   */
+  public synchronized ImmutableMap<String, NumberCounter> getCopy()
+  {
+    return ImmutableMap.copyOf(cache);
+  }
+
+  public static class Serializer extends JsonSerializer<Counters>
+  {
+
+    @Override
+    public void serialize(Counters value, JsonGenerator jgen, SerializerProvider provider)
+      throws IOException
+    {
+      jgen.writeObject(value.getCopy());
+    }
+  }
+
+  public static class Aggregator implements Context.CountersAggregator, Serializable
+  {
+
+    @SuppressWarnings("ConstantConditions")
+    @Override
+    public Object aggregate(Collection<?> countersList)
+    {
+      //counter key -> (aggregate method -> aggregated value)
+      Map<String, Map<String, Number>> result = Maps.newHashMap();
+
+      NumberCounter viewOfCounters = ((Counters) countersList.iterator().next()).getCopy().values().iterator().next();
+      if (viewOfCounters.getAggregateMethods() != null) {
+
+        List<NumberCounter.AggregateMethod> aggregateMethods = viewOfCounters.getAggregateMethods();
+
+        boolean calculateSumOnlyForAvg = aggregateMethods.contains(NumberCounter.AggregateMethod.AVERAGE) &&
+          !aggregateMethods.contains(NumberCounter.AggregateMethod.SUM);
+
+        int count = 0;
+        for (Object counter : countersList) {
+          count++;
+          Counters counters = (Counters) counter;
+
+          ImmutableMap<String, NumberCounter> copy = counters.getCopy();
+
+          for (Map.Entry<String, NumberCounter> entry : copy.entrySet()) {
+
+            Map<String, Number> subMap = result.get(entry.getKey());
+            if (subMap == null) {
+              subMap = Maps.newHashMap();
+              result.put(entry.getKey(), subMap);
+            }
+
+            for (NumberCounter.AggregateMethod method : aggregateMethods) {
+              Number first = subMap.get(method.getDisplayName());
+              Number updatedVal = null;
+
+              if (method == NumberCounter.AggregateMethod.MIN) {
+                updatedVal = getMinOf(first, entry.getValue().getNumberValue());
+              }
+              else if (method == NumberCounter.AggregateMethod.MAX) {
+                updatedVal = getMaxOf(first, entry.getValue().getNumberValue());
+              }
+              else if (method == NumberCounter.AggregateMethod.SUM || calculateSumOnlyForAvg) {
+                updatedVal = getSumOf(first, entry.getValue().getNumberValue());
+              }
+              else if (method == NumberCounter.AggregateMethod.AVERAGE && count == countersList.size()) {
+                updatedVal = subMap.get(
+                  NumberCounter.AggregateMethod.SUM.getDisplayName()).doubleValue() / (count * 1.0);
+
+                if (calculateSumOnlyForAvg) {
+                  subMap.remove(method.getDisplayName());
+                }
+              }
+              if (updatedVal != null) {
+                subMap.put(method.getDisplayName(), updatedVal);
+              }
+            }
+
+          }
+        }
+      }
+
+      return result;
+    }
+
+    private Number getMinOf(@Nullable Number first, @NotNull Number second)
+    {
+      if (first == null) {
+        return second;
+      }
+      if (first instanceof Integer || first instanceof Long) {
+        return Math.min(first.longValue(), first.longValue());
+      }
+      return Math.min(first.doubleValue(), first.doubleValue());
+    }
+
+    private Number getMaxOf(@Nullable Number first, @NotNull Number second)
+    {
+      if (first == null) {
+        return second;
+      }
+      if (first instanceof Integer || first instanceof Long) {
+        return Math.max(first.longValue(), first.longValue());
+      }
+      return Math.max(first.doubleValue(), first.doubleValue());
+    }
+
+    private Number getSumOf(@Nullable Number first, @NotNull Number second)
+    {
+      if (first == null) {
+        return second;
+      }
+      if (first instanceof Integer || first instanceof Long) {
+        return first.longValue() + first.longValue();
+      }
+      return second.doubleValue() + second.doubleValue();
+    }
+
+    private static final long serialVersionUID = 201503091713L;
+
+  }
+}

--- a/library/src/main/java/com/datatorrent/lib/counters/Counters.java
+++ b/library/src/main/java/com/datatorrent/lib/counters/Counters.java
@@ -93,7 +93,6 @@ public class Counters
   public static class Aggregator implements Context.CountersAggregator, Serializable
   {
 
-    @SuppressWarnings("ConstantConditions")
     @Override
     public Object aggregate(Collection<?> countersList)
     {
@@ -105,7 +104,7 @@ public class Counters
 
         List<NumberCounter.AggregateMethod> aggregateMethods = viewOfCounters.getAggregateMethods();
 
-        boolean calculateSumOnlyForAvg = aggregateMethods.contains(NumberCounter.AggregateMethod.AVERAGE) &&
+        boolean calculateSumOnlyForAvg = aggregateMethods.contains(NumberCounter.AggregateMethod.AVG) &&
           !aggregateMethods.contains(NumberCounter.AggregateMethod.SUM);
 
         int count = 0;
@@ -136,7 +135,7 @@ public class Counters
               else if (method == NumberCounter.AggregateMethod.SUM || calculateSumOnlyForAvg) {
                 updatedVal = getSumOf(first, entry.getValue().getNumberValue());
               }
-              else if (method == NumberCounter.AggregateMethod.AVERAGE && count == countersList.size()) {
+              else if (method == NumberCounter.AggregateMethod.AVG && count == countersList.size()) {
                 updatedVal = subMap.get(
                   NumberCounter.AggregateMethod.SUM.getDisplayName()).doubleValue() / (count * 1.0);
 

--- a/library/src/main/java/com/datatorrent/lib/counters/NumberCounter.java
+++ b/library/src/main/java/com/datatorrent/lib/counters/NumberCounter.java
@@ -40,7 +40,7 @@ public interface NumberCounter
 
   public static enum AggregateMethod
   {
-    AVERAGE("average"), SUM("sum"), MIN("min"), MAX("max");
+    AVG("avg"), SUM("sum"), MIN("min"), MAX("max");
 
     private final String displayName;
 

--- a/library/src/main/java/com/datatorrent/lib/counters/NumberCounter.java
+++ b/library/src/main/java/com/datatorrent/lib/counters/NumberCounter.java
@@ -38,23 +38,6 @@ public interface NumberCounter
    */
   List<AggregateMethod> getAggregateMethods();
 
-  public static enum AggregateMethod
-  {
-    AVG("avg"), SUM("sum"), MIN("min"), MAX("max");
-
-    private final String displayName;
-
-    AggregateMethod(String displayName)
-    {
-      this.displayName = displayName;
-    }
-
-    public String getDisplayName()
-    {
-      return displayName;
-    }
-  }
-
   public static class IntegerCounter extends MutableInt implements NumberCounter
   {
     @Override
@@ -66,7 +49,8 @@ public interface NumberCounter
     @Override
     public List<AggregateMethod> getAggregateMethods()
     {
-      return Lists.newArrayList(AggregateMethod.SUM);
+      return Lists.newArrayList(new AggregateMethod.AvgAggregateMethod(), new AggregateMethod.SumAggregateMethod(),
+        new AggregateMethod.MaxAggregateMethod(), new AggregateMethod.MinAggregateMethod());
     }
   }
 
@@ -82,7 +66,8 @@ public interface NumberCounter
     @Override
     public List<AggregateMethod> getAggregateMethods()
     {
-      return Lists.newArrayList(AggregateMethod.SUM);
+      return Lists.newArrayList(new AggregateMethod.AvgAggregateMethod(), new AggregateMethod.SumAggregateMethod(),
+        new AggregateMethod.MaxAggregateMethod(), new AggregateMethod.MinAggregateMethod());
     }
   }
 
@@ -98,7 +83,8 @@ public interface NumberCounter
     @Override
     public List<AggregateMethod> getAggregateMethods()
     {
-      return Lists.newArrayList(AggregateMethod.SUM);
+      return Lists.newArrayList(new AggregateMethod.AvgAggregateMethod(), new AggregateMethod.SumAggregateMethod(),
+        new AggregateMethod.MaxAggregateMethod(), new AggregateMethod.MinAggregateMethod());
     }
   }
 }

--- a/library/src/main/java/com/datatorrent/lib/counters/NumberCounter.java
+++ b/library/src/main/java/com/datatorrent/lib/counters/NumberCounter.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.lang.mutable.Mutable;
 import org.apache.commons.lang.mutable.MutableDouble;
 import org.apache.commons.lang.mutable.MutableInt;
 import org.apache.commons.lang.mutable.MutableLong;

--- a/library/src/main/java/com/datatorrent/lib/counters/NumberCounter.java
+++ b/library/src/main/java/com/datatorrent/lib/counters/NumberCounter.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2015 DataTorrent, Inc. ALL Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.lib.counters;
+
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.lang.mutable.Mutable;
+import org.apache.commons.lang.mutable.MutableDouble;
+import org.apache.commons.lang.mutable.MutableInt;
+import org.apache.commons.lang.mutable.MutableLong;
+
+import com.google.common.collect.Lists;
+
+public interface NumberCounter
+{
+  /**
+   * @return value of the counter
+   */
+  @NotNull
+  Number getNumberValue();
+
+  /**
+   * @return null if should not be aggregated; list of aggregating methods otherwise.
+   */
+  List<AggregateMethod> getAggregateMethods();
+
+  public static enum AggregateMethod
+  {
+    AVERAGE("average"), SUM("sum"), MIN("min"), MAX("max");
+
+    private final String displayName;
+
+    AggregateMethod(String displayName)
+    {
+      this.displayName = displayName;
+    }
+
+    public String getDisplayName()
+    {
+      return displayName;
+    }
+  }
+
+  public static class IntegerCounter extends MutableInt implements NumberCounter
+  {
+    @Override
+    public Number getNumberValue()
+    {
+      return intValue();
+    }
+
+    @Override
+    public List<AggregateMethod> getAggregateMethods()
+    {
+      return Lists.newArrayList(AggregateMethod.SUM);
+    }
+  }
+
+  public static class LongCounter extends MutableLong implements NumberCounter
+  {
+
+    @Override
+    public Number getNumberValue()
+    {
+      return longValue();
+    }
+
+    @Override
+    public List<AggregateMethod> getAggregateMethods()
+    {
+      return Lists.newArrayList(AggregateMethod.SUM);
+    }
+  }
+
+  public static class DoubleCounter extends MutableDouble implements NumberCounter
+  {
+
+    @Override
+    public Number getNumberValue()
+    {
+      return doubleValue();
+    }
+
+    @Override
+    public List<AggregateMethod> getAggregateMethods()
+    {
+      return Lists.newArrayList(AggregateMethod.SUM);
+    }
+  }
+}


### PR DESCRIPTION
An incomplete pull request. Just created for initial review 

Deprecated BasicCounters
- BasicCounters can only be a group of ints or longs or doubles. It cannot be a mix of number types.
- The aggregation of basic counters to a logical counter does min, max, sum, avg always. There is no flexibility to provide your own aggregation method and do selective aggregations.

Provided Counters which are a group of NumberCounter. Added an AggregateMethod which can be customized as well.
- Counters can be a mix of all numeric types.
- it gives flexibility to provide what aggregations can be done. This can be used for aggregating physical counters to logical counters as well as other aggregations which are needed by AppDataFramework.
- Custom aggregations can be plugged in.