### PR TITLE
Implemented Clone when cloning capability is needed

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/bucket/BucketManager.java
+++ b/library/src/main/java/com/datatorrent/lib/bucket/BucketManager.java
@@ -60,7 +60,7 @@ import com.datatorrent.lib.counters.BasicCounters;
  * @param <T> event type
  * @since 0.9.4
  */
-public interface BucketManager<T extends Bucketable>
+public interface BucketManager<T extends Bucketable> extends Cloneable
 {
   void setBucketStore(@Nonnull BucketStore<T> bucketStore);
 
@@ -140,8 +140,9 @@ public interface BucketManager<T extends Bucketable>
    * Constructs a new {@link BucketManager} with only the settings and not the data.
    *
    * @return newly created manager without any data.
+   * @throws java.lang.CloneNotSupportedException
    */
-  BucketManager<T> cloneWithProperties();
+  BucketManager<T> clone() throws CloneNotSupportedException;
 
   void setBucketCounters(@Nonnull BasicCounters<MutableLong> stats);
 

--- a/library/src/main/java/com/datatorrent/lib/bucket/BucketManagerImpl.java
+++ b/library/src/main/java/com/datatorrent/lib/bucket/BucketManagerImpl.java
@@ -452,23 +452,14 @@ public class BucketManagerImpl<T extends Bucketable> implements BucketManager<T>
   }
 
   @Override
-  public BucketManagerImpl<T> cloneWithProperties()
+  public BucketManagerImpl<T> clone() throws CloneNotSupportedException
   {
-    BucketManagerImpl<T> clone = new BucketManagerImpl<T>();
-    copyPropertiesTo(clone);
+    @SuppressWarnings("unchecked")
+    BucketManagerImpl<T> clone = (BucketManagerImpl<T>)super.clone();
+    clone.setBucketStore(clone.getBucketStore().clone());
     return clone;
   }
 
-  protected void copyPropertiesTo(BucketManagerImpl<T> other)
-  {
-    other.writeEventKeysOnly = writeEventKeysOnly;
-    other.noOfBuckets = noOfBuckets;
-    other.noOfBucketsInMemory = noOfBucketsInMemory;
-    other.maxNoOfBucketsInMemory = maxNoOfBucketsInMemory;
-    other.millisPreventingBucketEviction = millisPreventingBucketEviction;
-    other.bucketStore = bucketStore;
-    other.committedWindow = committedWindow;
-  }
 
   @SuppressWarnings("ClassMayBeInterface")
   private static class Lock

--- a/library/src/main/java/com/datatorrent/lib/bucket/BucketStore.java
+++ b/library/src/main/java/com/datatorrent/lib/bucket/BucketStore.java
@@ -23,9 +23,10 @@ import javax.annotation.Nonnull;
 /**
  * Bucket store API.<br/>
  *
+ * @param <T>
  * @since 0.9.4
  */
-public interface BucketStore<T extends Bucketable>
+public interface BucketStore<T extends Bucketable> extends Cloneable
 {
   /**
    * Performs setup operations eg. crate database connections, delete events of windows greater than last committed
@@ -77,6 +78,7 @@ public interface BucketStore<T extends Bucketable>
    * @param writeEventKeysOnly
    */
   void setWriteEventKeysOnly(boolean writeEventKeysOnly);
+  BucketStore<T> clone() throws CloneNotSupportedException;
 
   public interface ExpirableBucketStore<T extends Bucketable & Event> extends BucketStore<T>
   {

--- a/library/src/main/java/com/datatorrent/lib/bucket/ExpirableHdfsBucketStore.java
+++ b/library/src/main/java/com/datatorrent/lib/bucket/ExpirableHdfsBucketStore.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * <p>ExpirableHdfsBucketStore class.</p>
  *
+ * @param <T>
  * @since 0.9.5
  */
 public class ExpirableHdfsBucketStore<T extends Bucketable & Event> extends HdfsBucketStore<T> implements BucketStore.ExpirableBucketStore<T>
@@ -71,6 +72,13 @@ public class ExpirableHdfsBucketStore<T extends Bucketable & Event> extends Hdfs
         }
       }
     }
+  }
+  
+  @Override
+  @SuppressWarnings("unchecked")
+  public ExpirableHdfsBucketStore<T> clone() throws CloneNotSupportedException
+  {
+    return (ExpirableHdfsBucketStore<T>)super.clone();
   }
 
   private static transient final Logger logger = LoggerFactory.getLogger(ExpirableHdfsBucketStore.class);

--- a/library/src/main/java/com/datatorrent/lib/bucket/HdfsBucketStore.java
+++ b/library/src/main/java/com/datatorrent/lib/bucket/HdfsBucketStore.java
@@ -369,6 +369,13 @@ public class HdfsBucketStore<T extends Bucketable> implements BucketStore<T>
     return result;
   }
 
+  @Override
+  @SuppressWarnings("unchecked")
+  public HdfsBucketStore<T> clone() throws CloneNotSupportedException
+  {
+    return (HdfsBucketStore<T>)super.clone();
+  }
+
   private class Exchange<E> implements Comparable<Exchange<E>>
   {
     final long window;

--- a/library/src/main/java/com/datatorrent/lib/bucket/NonOperationalBucketStore.java
+++ b/library/src/main/java/com/datatorrent/lib/bucket/NonOperationalBucketStore.java
@@ -95,5 +95,12 @@ public class NonOperationalBucketStore<T extends Bucketable & Event> implements 
   {
   }
 
+  @Override
+  @SuppressWarnings("unchecked")
+  public NonOperationalBucketStore<T> clone() throws CloneNotSupportedException
+  {
+    return (NonOperationalBucketStore<T>)super.clone();
+  }
+
   private static transient final Logger logger = LoggerFactory.getLogger(NonOperationalBucketStore.class);
 }

--- a/library/src/main/java/com/datatorrent/lib/bucket/TimeBasedBucketManagerImpl.java
+++ b/library/src/main/java/com/datatorrent/lib/bucket/TimeBasedBucketManagerImpl.java
@@ -84,15 +84,20 @@ public class TimeBasedBucketManagerImpl<T extends Event & Bucketable> extends Bu
     recomputeNumBuckets();
   }
 
-  @Override
-  public TimeBasedBucketManagerImpl<T> cloneWithProperties()
+  /*
+   * Gets the maximum Times Per Buckets.
+   */
+  public Long[] getMaxTimesPerBuckets()
   {
-    TimeBasedBucketManagerImpl<T> clone = new TimeBasedBucketManagerImpl<T>();
-    copyPropertiesTo(clone);
-    clone.bucketSpanInMillis = bucketSpanInMillis;
-    clone.startOfBucketsInMillis = startOfBucketsInMillis;
-    clone.expiryTime = expiryTime;
-    clone.maxTimesPerBuckets = maxTimesPerBuckets;
+    return maxTimesPerBuckets;
+  }
+
+  @Override
+  public TimeBasedBucketManagerImpl<T> clone() throws CloneNotSupportedException
+  {
+    @SuppressWarnings("unchecked")
+    TimeBasedBucketManagerImpl<T> clone = (TimeBasedBucketManagerImpl<T>)super.clone();
+    clone.maxTimesPerBuckets = maxTimesPerBuckets.clone();
     return clone;
   }
 

--- a/library/src/main/java/com/datatorrent/lib/dedup/Deduper.java
+++ b/library/src/main/java/com/datatorrent/lib/dedup/Deduper.java
@@ -325,7 +325,12 @@ public abstract class Deduper<INPUT extends Bucketable, OUTPUT>
       deduperInstance.partitionKeys = deduperPartition.getPartitionKeys().get(input).partitions;
       deduperInstance.partitionMask = lPartitionMask;
       logger.debug("partitions {},{}", deduperInstance.partitionKeys, deduperInstance.partitionMask);
-      deduperInstance.bucketManager = bucketManager.cloneWithProperties();
+      try {
+        deduperInstance.bucketManager = bucketManager.clone();
+      }
+      catch (CloneNotSupportedException ex) {
+        DTThrowable.rethrow(ex);
+      }
 
       for (int partitionKey : deduperInstance.partitionKeys) {
         partitionKeyToStorageManagers.put(partitionKey, deduperInstance.bucketManager);

--- a/library/src/test/java/com/datatorrent/lib/bucket/BucketManagerTest.java
+++ b/library/src/test/java/com/datatorrent/lib/bucket/BucketManagerTest.java
@@ -129,7 +129,8 @@ public class BucketManagerTest
     BucketManagerImpl<DummyEvent> clonedManager = manager.clone();
     Assert.assertNull(clonedManager.getBucket(bucket1));
     Assert.assertNotNull(clonedManager.getBucket(bucket2));
-    Assert.assertTrue(clonedManager.bucketStore.equals(manager.bucketStore));
+    Assert.assertNotNull(clonedManager.getBucketStore());
+    Assert.assertNotNull(clonedManager.bucketStore.equals(manager.bucketStore));
     Assert.assertTrue(clonedManager.writeEventKeysOnly==manager.writeEventKeysOnly);
     Assert.assertTrue(clonedManager.noOfBuckets==manager.noOfBuckets);
     Assert.assertTrue(clonedManager.noOfBucketsInMemory==manager.noOfBucketsInMemory);

--- a/library/src/test/java/com/datatorrent/lib/bucket/BucketManagerTest.java
+++ b/library/src/test/java/com/datatorrent/lib/bucket/BucketManagerTest.java
@@ -118,6 +118,25 @@ public class BucketManagerTest
     }
   }
 
+  @Test
+  public void testClone() throws CloneNotSupportedException, InterruptedException
+  {
+    manager.loadBucketData(bucket1);
+    eventBucketExchanger.exchange(null);
+    manager.loadBucketData(bucket2);
+    eventBucketExchanger.exchange(null);
+    Assert.assertNotNull(manager.getBucket(bucket2));
+    BucketManagerImpl<DummyEvent> clonedManager = manager.clone();
+    Assert.assertNull(clonedManager.getBucket(bucket1));
+    Assert.assertNotNull(clonedManager.getBucket(bucket2));
+    Assert.assertTrue(clonedManager.bucketStore.equals(manager.bucketStore));
+    Assert.assertTrue(clonedManager.writeEventKeysOnly==manager.writeEventKeysOnly);
+    Assert.assertTrue(clonedManager.noOfBuckets==manager.noOfBuckets);
+    Assert.assertTrue(clonedManager.noOfBucketsInMemory==manager.noOfBucketsInMemory);
+    Assert.assertTrue(clonedManager.maxNoOfBucketsInMemory==manager.maxNoOfBucketsInMemory);
+    Assert.assertTrue(clonedManager.millisPreventingBucketEviction== manager.millisPreventingBucketEviction);
+    Assert.assertTrue(clonedManager.committedWindow==manager.committedWindow);
+  }
 
   @BeforeClass
   public static void setup() throws Exception

--- a/library/src/test/java/com/datatorrent/lib/bucket/TimeBasedBucketManagerTest.java
+++ b/library/src/test/java/com/datatorrent/lib/bucket/TimeBasedBucketManagerTest.java
@@ -61,6 +61,21 @@ public class TimeBasedBucketManagerTest
     Assert.assertEquals("valid event", bucket2, rBucket2);
   }
 
+  @Test
+  public void testClone() throws CloneNotSupportedException, InterruptedException
+  {
+    TimeBasedBucketManagerImpl<DummyEvent> clonedManager = manager.clone();
+    Assert.assertNotNull(clonedManager);
+    Assert.assertTrue(clonedManager.bucketStore.equals(manager.bucketStore));
+    Assert.assertTrue(clonedManager.writeEventKeysOnly==manager.writeEventKeysOnly);
+    Assert.assertTrue(clonedManager.noOfBuckets==manager.noOfBuckets);
+    Assert.assertTrue(clonedManager.noOfBucketsInMemory==manager.noOfBucketsInMemory);
+    Assert.assertTrue(clonedManager.maxNoOfBucketsInMemory==manager.maxNoOfBucketsInMemory);
+    Assert.assertTrue(clonedManager.millisPreventingBucketEviction== manager.millisPreventingBucketEviction);
+    Assert.assertTrue(clonedManager.committedWindow==manager.committedWindow);
+    Assert.assertTrue(clonedManager.getMaxTimesPerBuckets().length== manager.getMaxTimesPerBuckets().length);
+  }
+
   @BeforeClass
   public static void setup() throws Exception
   {

--- a/library/src/test/java/com/datatorrent/lib/bucket/TimeBasedBucketManagerTest.java
+++ b/library/src/test/java/com/datatorrent/lib/bucket/TimeBasedBucketManagerTest.java
@@ -66,6 +66,7 @@ public class TimeBasedBucketManagerTest
   {
     TimeBasedBucketManagerImpl<DummyEvent> clonedManager = manager.clone();
     Assert.assertNotNull(clonedManager);
+    Assert.assertNotNull(clonedManager.getBucketStore());
     Assert.assertTrue(clonedManager.bucketStore.equals(manager.bucketStore));
     Assert.assertTrue(clonedManager.writeEventKeysOnly==manager.writeEventKeysOnly);
     Assert.assertTrue(clonedManager.noOfBuckets==manager.noOfBuckets);


### PR DESCRIPTION
Deduper code implements callback to get instance of the object. This callback semantically is equivalent of clone but unlike clone accidentprone. Fixed it by replacing it with clone method.