### PR TITLE
Changes for ByteArrayToStringConverter Operator

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/converter/ByteArrayToStringConverterOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/converter/ByteArrayToStringConverterOperator.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2015 DataTorrent, Inc. ALL Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.lib.converter;
+
+import com.datatorrent.api.BaseOperator;
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
+import java.nio.charset.Charset;
+
+/*
+ * This operator converts Byte Array to String. User gets the option of providing character Encoding.
+ */
+public class ByteArrayToStringConverterOperator extends BaseOperator
+{
+  private Charset characterEncoding;
+
+  public String getCharacterEncoding()
+  {
+    return characterEncoding.name();
+  }
+
+  public void setCharacterEncoding(String characterEncoding)
+  {
+    this.characterEncoding = Charset.forName(characterEncoding);
+  }
+
+
+
+  /**
+   * Input port which accepts byte array.
+   */
+  public final transient DefaultInputPort<byte[]> input = new DefaultInputPort<byte[]>()
+  {
+    @Override
+    public void process(byte[] message)
+    {
+      output.emit(characterEncoding == null? new String(message): new String(message, characterEncoding));
+    }
+
+  };
+
+  /**
+   * Output port which outputs String converted from byte array.
+   */
+  public final transient DefaultOutputPort<String> output = new DefaultOutputPort<String>();
+
+}

--- a/library/src/test/java/com/datatorrent/lib/converter/ByteArrayToStringConverterTest.java
+++ b/library/src/test/java/com/datatorrent/lib/converter/ByteArrayToStringConverterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2015 DataTorrent, Inc. ALL Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datatorrent.lib.converter;
+
+import com.datatorrent.lib.testbench.CollectorTestSink;
+import com.datatorrent.lib.util.TestUtils;
+import java.io.UnsupportedEncodingException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ByteArrayToStringConverterTest
+{
+  @Test
+  public void testByteArrayToStringConversion() throws UnsupportedEncodingException
+  {
+    ByteArrayToStringConverterOperator testop = new ByteArrayToStringConverterOperator();
+    String test1 = "hello world with UTF8";
+    byte[] utf8Bytes = test1.getBytes("UTF-8");
+    String test2 = "hello world@#'!!!.: with UTF-16";
+    byte[] asciiBytes = test2.getBytes("UTF-16");
+    CollectorTestSink<String> testsink = new CollectorTestSink<String>();
+    TestUtils.setSink(testop.output, testsink);
+    testop.beginWindow(0);
+    testop.setCharacterEncoding("UTF-8");
+    testop.input.put(utf8Bytes);
+    testop.setCharacterEncoding("UTF-16");
+    testop.input.put(asciiBytes);
+    testop.endWindow();
+
+    Assert.assertEquals(2,testsink.collectedTuples.size());
+    for (String output: testsink.collectedTuples) {
+      logger.debug("output is {}",output);
+      Assert.assertEquals(test1, output);
+      test1 = test2;
+    }
+  }
+
+  @Test
+  public void testByteArrayToStringConversionDefaultEncoding() throws UnsupportedEncodingException
+  {
+    ByteArrayToStringConverterOperator testop = new ByteArrayToStringConverterOperator();
+    String test1 = "hello world with default encoding";
+    byte[] bytes = test1.getBytes();
+    CollectorTestSink<String> testsink = new CollectorTestSink<String>();
+    TestUtils.setSink(testop.output, testsink);
+    testop.beginWindow(0);
+    testop.input.put(bytes);
+    testop.endWindow();
+
+    Assert.assertEquals(1,testsink.collectedTuples.size());
+    Assert.assertEquals(test1, testsink.collectedTuples.get(0));
+
+  }
+  private static final Logger logger = LoggerFactory.getLogger(ByteArrayToStringConverterTest.class);
+}


### PR DESCRIPTION
Adding ByteArrayToString Converter which can be used with KafkaSinglePortByteArrayInputOperator in order to work as  KafkaSinglePortStringInputOperator . This will help in writing app builder specific operators also.KafkaSinglePortByteArrayInputOperator was already added in contrib.