### PR TITLE
Deprecated UniqueCounterValue since it has no checks for uniqueness a…

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/algo/UniqueCounterValue.java
+++ b/library/src/main/java/com/datatorrent/lib/algo/UniqueCounterValue.java
@@ -73,9 +73,13 @@ import com.datatorrent.api.Operator.Unifier;
  * @displayName Count Unique Values
  * @category Algorithmic
  * @tags count
+ * @deprecated Despite its name, this operator simply counts the number of tuples and has
+ *    no checks for uniqueness. Please use {@link com.datatorrent.lib.stream.Counter}
+ *    to get a simple tuple count.
  *
  * @since 0.3.2
  */
+@Deprecated
 public class UniqueCounterValue<K> extends BaseOperator implements Unifier<Integer>
 {
   /**


### PR DESCRIPTION
The name of this class and some of the javadoc comments are misleading since there are no uniqueness checks in the code. Deprecating it in favor of stream.Counter which provides a simple tuple count.
