### PR TITLE
MLHR-1724 Added concrete put operators and tests

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -528,7 +528,7 @@
     <dependency>
       <groupId>com.aerospike</groupId>
       <artifactId>aerospike-client</artifactId>
-      <version>3.0.26</version>
+      <version>3.0.35</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/contrib/src/main/java/com/datatorrent/contrib/aerospike/AbstractAerospikeNonTransactionalPutOperator.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/aerospike/AbstractAerospikeNonTransactionalPutOperator.java
@@ -20,8 +20,8 @@ import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Bin;
 import com.aerospike.client.Key;
 import com.datatorrent.lib.db.AbstractStoreOutputOperator;
-import org.python.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -32,15 +32,15 @@ import java.util.List;
  * @displayName Abstract Aerospike Non Transactional Put
  * @category Database
  * @tags output operator, put, non transactional
- * @param <T>type of tuple</T>
+ * @param <T> type of tuple
  * @since 1.0.4
  */
 public abstract class AbstractAerospikeNonTransactionalPutOperator<T> extends AbstractStoreOutputOperator<T,AerospikeStore> {
 
-  private transient List<Bin> bins;
+  private transient final List<Bin> bins;
   public AbstractAerospikeNonTransactionalPutOperator() {
     super();
-    bins = Lists.newArrayList();
+    bins = new ArrayList<Bin>();
   }
 
   /**
@@ -52,17 +52,17 @@ public abstract class AbstractAerospikeNonTransactionalPutOperator<T> extends Ab
    * @return key for the row to be updated in the database
    * @throws AerospikeException
    */
-  protected abstract Key getUpdatedBins(T tuple,List<Bin> bins) throws AerospikeException;
+  protected abstract Key getUpdatedBins(T tuple, List<Bin> bins) throws AerospikeException;
 
   @Override
   public void processTuple(T tuple) {
 
-    Key key=null;
-    Bin[] binsArray = null;
+    Key key;
+    Bin[] binsArray;
     try {
       key = getUpdatedBins(tuple,bins);
-      binsArray=new Bin[bins.size()];
-      binsArray=bins.toArray(binsArray);
+      binsArray = new Bin[bins.size()];
+      binsArray = bins.toArray(binsArray);
       store.getClient().put(null, key, binsArray);
       bins.clear();
     }

--- a/contrib/src/main/java/com/datatorrent/contrib/aerospike/AbstractAerospikeTransactionalPutOperator.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/aerospike/AbstractAerospikeTransactionalPutOperator.java
@@ -20,8 +20,8 @@ import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Bin;
 import com.aerospike.client.Key;
 import com.datatorrent.lib.db.AbstractBatchTransactionableStoreOutputOperator;
-import com.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -38,16 +38,16 @@ import java.util.List;
  * @displayName Abstract Aerospike Transactional Put
  * @category Database
  * @tags output operator, put, transactional
- * @param <T>type of tuple</T>
+ * @param <T>type of tuple
  * @since 1.0.4
  */
 public abstract class AbstractAerospikeTransactionalPutOperator<T> extends AbstractBatchTransactionableStoreOutputOperator<T, AerospikeTransactionalStore> {
 
-  private transient List<Bin> bins;
+  private transient final List<Bin> bins;
   public AbstractAerospikeTransactionalPutOperator() {
 
     super();
-    bins = Lists.newArrayList();
+    bins = new ArrayList<Bin>();
   }
 
   /**
@@ -59,18 +59,18 @@ public abstract class AbstractAerospikeTransactionalPutOperator<T> extends Abstr
    * @return key for the row to be updated in the database
    * @throws AerospikeException
    */
-  protected abstract Key getUpdatedBins(T tuple,List<Bin> bins) throws AerospikeException;
+  protected abstract Key getUpdatedBins(T tuple, List<Bin> bins) throws AerospikeException;
 
   @Override
   public void processBatch(Collection<T> tuples)
   {
-    Key key=null;
-    Bin[] binsArray = null;
+    Key key;
+    Bin[] binsArray;
     try {
       for(T tuple: tuples) {
         key = getUpdatedBins(tuple,bins);
-        binsArray=new Bin[bins.size()];
-        binsArray=bins.toArray(binsArray);
+        binsArray = new Bin[bins.size()];
+        binsArray = bins.toArray(binsArray);
         store.getClient().put(null, key, binsArray);
         bins.clear();
       }

--- a/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeNonTransactionalPutOperator.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeNonTransactionalPutOperator.java
@@ -26,7 +26,7 @@ import com.aerospike.client.Bin;
 import com.aerospike.client.Key;
 
 import com.datatorrent.lib.util.PojoUtils;
-import com.datatorrent.lib.util.PojoUtils.GetterObject;
+import com.datatorrent.lib.util.PojoUtils.Getter;
 
 /**
  * <p>
@@ -47,8 +47,8 @@ public class AerospikeNonTransactionalPutOperator extends AbstractAerospikeNonTr
   @NotNull
   private ArrayList<String> expressions;
 
-  private GetterObject keyGetter;
-  private GetterObject binsGetter;
+  private Getter<Object, Key> keyGetter;
+  private Getter<Object, List> binsGetter;
 
   // required by App Builder
   public AerospikeNonTransactionalPutOperator()
@@ -83,11 +83,11 @@ public class AerospikeNonTransactionalPutOperator extends AbstractAerospikeNonTr
   {
     if (null == keyGetter) {    // first tuple
       Class<?> tupleClass = tuple.getClass();
-      keyGetter  = PojoUtils.createGetterObject(tupleClass, expressions.get(0));
-      binsGetter = PojoUtils.createGetterObject(tupleClass, expressions.get(1));
+      keyGetter  = PojoUtils.createGetter(tupleClass, expressions.get(0), Key.class);
+      binsGetter = PojoUtils.createGetter(tupleClass, expressions.get(1), List.class);
     }
-    Key key = (Key)keyGetter.get(tuple);
-    List<Bin> binList = (List<Bin>)binsGetter.get(tuple);
+    Key key = keyGetter.get(tuple);
+    List<Bin> binList = binsGetter.get(tuple);
     if ( ! (null == binList || binList.isEmpty()) ) {
       list.addAll(binList);
     }

--- a/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeNonTransactionalPutOperator.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeNonTransactionalPutOperator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2015 DataTorrent, Inc. ALL Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datatorrent.contrib.aerospike;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.aerospike.client.Bin;
+import com.aerospike.client.Key;
+
+import com.datatorrent.lib.util.PojoUtils;
+import com.datatorrent.lib.util.PojoUtils.GetterObject;
+
+/**
+ * <p>
+ * A generic implementation of {@link AbstractAerospikeNonTransactionalPutOperator} which can
+ * take a POJO.
+ * </p>
+ * @displayName Aerospike Non-Transactional Put
+ * @category Database
+ * @tags output operator, put, non-transactional
+ * @since 2.1.0
+ */
+public class AerospikeNonTransactionalPutOperator extends AbstractAerospikeNonTransactionalPutOperator<Object>
+{
+  private static transient final Logger LOG
+    = LoggerFactory.getLogger(AerospikeNonTransactionalPutOperator.class);
+
+  // Two element list; first retrieves the record key and second the list of bins in this tuple
+  @NotNull
+  private ArrayList<String> expressions;
+
+  private GetterObject keyGetter;
+  private GetterObject binsGetter;
+
+  // required by App Builder
+  public AerospikeNonTransactionalPutOperator()
+  {
+  }
+
+  /*
+   * Two Java expressions that will yield the key and the list of modified Bins
+   * for the destination record of this tuple
+   * Example: {"getKey()", "getBins()"}
+   */
+  public ArrayList<String> getExpressions()
+  {
+    return expressions;
+  }
+
+  /*
+   * Set field retrieval list of expressions.
+   * @param ArrayList of field retrieval expressions
+   */
+  public void setExpressions(ArrayList<String> e)
+  {
+    this.expressions = e;
+  }
+
+  /*
+   * Not a property, so don't show in App Builder
+   * @omitFromUI
+   */
+  @Override
+  public Key getUpdatedBins(Object tuple, List<Bin> list)
+  {
+    if (null == keyGetter) {    // first tuple
+      Class<?> tupleClass = tuple.getClass();
+      keyGetter  = PojoUtils.createGetterObject(tupleClass, expressions.get(0));
+      binsGetter = PojoUtils.createGetterObject(tupleClass, expressions.get(1));
+    }
+    Key key = (Key)keyGetter.get(tuple);
+    List<Bin> binList = (List<Bin>)binsGetter.get(tuple);
+    if ( ! (null == binList || binList.isEmpty()) ) {
+      list.addAll(binList);
+    }
+    return key;
+  }
+
+}

--- a/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeNonTransactionalPutOperator.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeNonTransactionalPutOperator.java
@@ -47,8 +47,8 @@ public class AerospikeNonTransactionalPutOperator extends AbstractAerospikeNonTr
   @NotNull
   private ArrayList<String> expressions;
 
-  private Getter<Object, Key> keyGetter;
-  private Getter<Object, List> binsGetter;
+  private transient Getter<Object, Key> keyGetter;
+  private transient Getter<Object, List> binsGetter;
 
   // required by App Builder
   public AerospikeNonTransactionalPutOperator()
@@ -74,12 +74,8 @@ public class AerospikeNonTransactionalPutOperator extends AbstractAerospikeNonTr
     this.expressions = e;
   }
 
-  /*
-   * Not a property, so don't show in App Builder
-   * @omitFromUI
-   */
   @Override
-  public Key getUpdatedBins(Object tuple, List<Bin> list)
+  protected Key getUpdatedBins(Object tuple, List<Bin> list)
   {
     if (null == keyGetter) {    // first tuple
       Class<?> tupleClass = tuple.getClass();

--- a/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperator.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperator.java
@@ -49,8 +49,8 @@ public class AerospikeTransactionalPutOperator
   @NotNull
   private ArrayList<String> expressions;
 
-  private Getter<Object, Key> keyGetter;
-  private Getter<Object, List> binsGetter;
+  private transient Getter<Object, Key> keyGetter;
+  private transient Getter<Object, List> binsGetter;
 
   // required by App Builder
   public AerospikeTransactionalPutOperator()
@@ -76,12 +76,8 @@ public class AerospikeTransactionalPutOperator
     this.expressions = e;
   }
 
-  /*
-   * Not a property, so don't show in App Builder
-   * @omitFromUI
-   */
   @Override
-  public Key getUpdatedBins(Object tuple, List<Bin> list)
+  protected Key getUpdatedBins(Object tuple, List<Bin> list)
   {
     if (null == keyGetter) {    // first tuple
       Class<?> tupleClass = tuple.getClass();

--- a/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperator.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperator.java
@@ -92,7 +92,6 @@ public class AerospikeTransactionalPutOperator
     List<Bin> binList = (List<Bin>)binsGetter.get(tuple);
     if ( ! (null == binList || binList.isEmpty()) ) {
       list.addAll(binList);
-      System.out.println("getUpdatedBins:  list.size = " + binList.size());
     }
     return key;
   }

--- a/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperator.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperator.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2015 DataTorrent, Inc. ALL Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datatorrent.contrib.aerospike;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.aerospike.client.Bin;
+import com.aerospike.client.Key;
+
+import com.datatorrent.lib.util.PojoUtils;
+import com.datatorrent.lib.util.PojoUtils.GetterObject;
+
+/**
+ * <p>
+ * A generic implementation of
+ * {@link com.datatorrent.contrib.aerospike.AbstractAerospikeTransactionalPutOperator} which can
+ * take a POJO.
+ * </p>
+ * @displayName Aerospike Transactional Put
+ * @category Database
+ * @tags output operator, put, transactional
+ * @since 2.1.0
+ */
+public class AerospikeTransactionalPutOperator
+  extends AbstractAerospikeTransactionalPutOperator<Object>
+{
+  private static transient final Logger LOG
+    = LoggerFactory.getLogger(AerospikeTransactionalPutOperator.class);
+
+  // Two element list; first retrieves the record key and second the list of bins in this tuple
+  @NotNull
+  private ArrayList<String> expressions;
+
+  private GetterObject keyGetter;
+  private GetterObject binsGetter;
+
+  // required by App Builder
+  public AerospikeTransactionalPutOperator()
+  {
+  }
+
+  /*
+   * Two Java expressions that will yield the key and the list of modified Bins
+   * for the destination record of this tuple
+   * Example: {"getKey()", "getBins()"}
+   */
+  public ArrayList<String> getExpressions()
+  {
+    return expressions;
+  }
+
+  /*
+   * Set field retrieval list of expressions.
+   * @param ArrayList of field retrieval expressions
+   */
+  public void setExpressions(ArrayList<String> e)
+  {
+    this.expressions = e;
+  }
+
+  /*
+   * Not a property, so don't show in App Builder
+   * @omitFromUI
+   */
+  @Override
+  public Key getUpdatedBins(Object tuple, List<Bin> list)
+  {
+    if (null == keyGetter) {    // first tuple
+      System.out.println("getUpdatedBins: first time");
+      Class<?> tupleClass = tuple.getClass();
+      keyGetter  = PojoUtils.createGetterObject(tupleClass, expressions.get(0));
+      binsGetter = PojoUtils.createGetterObject(tupleClass, expressions.get(1));
+    }
+    Key key = (Key)keyGetter.get(tuple);
+    List<Bin> binList = (List<Bin>)binsGetter.get(tuple);
+    if ( ! (null == binList || binList.isEmpty()) ) {
+      list.addAll(binList);
+      System.out.println("getUpdatedBins:  list.size = " + binList.size());
+    }
+    return key;
+  }
+
+
+}

--- a/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperator.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperator.java
@@ -84,7 +84,6 @@ public class AerospikeTransactionalPutOperator
   public Key getUpdatedBins(Object tuple, List<Bin> list)
   {
     if (null == keyGetter) {    // first tuple
-      System.out.println("getUpdatedBins: first time");
       Class<?> tupleClass = tuple.getClass();
       keyGetter  = PojoUtils.createGetterObject(tupleClass, expressions.get(0));
       binsGetter = PojoUtils.createGetterObject(tupleClass, expressions.get(1));

--- a/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperator.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperator.java
@@ -26,7 +26,7 @@ import com.aerospike.client.Bin;
 import com.aerospike.client.Key;
 
 import com.datatorrent.lib.util.PojoUtils;
-import com.datatorrent.lib.util.PojoUtils.GetterObject;
+import com.datatorrent.lib.util.PojoUtils.Getter;
 
 /**
  * <p>
@@ -49,8 +49,8 @@ public class AerospikeTransactionalPutOperator
   @NotNull
   private ArrayList<String> expressions;
 
-  private GetterObject keyGetter;
-  private GetterObject binsGetter;
+  private Getter<Object, Key> keyGetter;
+  private Getter<Object, List> binsGetter;
 
   // required by App Builder
   public AerospikeTransactionalPutOperator()
@@ -85,11 +85,11 @@ public class AerospikeTransactionalPutOperator
   {
     if (null == keyGetter) {    // first tuple
       Class<?> tupleClass = tuple.getClass();
-      keyGetter  = PojoUtils.createGetterObject(tupleClass, expressions.get(0));
-      binsGetter = PojoUtils.createGetterObject(tupleClass, expressions.get(1));
+      keyGetter  = PojoUtils.createGetter(tupleClass, expressions.get(0), Key.class);
+      binsGetter = PojoUtils.createGetter(tupleClass, expressions.get(1), List.class);
     }
-    Key key = (Key)keyGetter.get(tuple);
-    List<Bin> binList = (List<Bin>)binsGetter.get(tuple);
+    Key key = keyGetter.get(tuple);
+    List<Bin> binList = binsGetter.get(tuple);
     if ( ! (null == binList || binList.isEmpty()) ) {
       list.addAll(binList);
     }

--- a/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeNonTransactionalPutOperatorTest.java
+++ b/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeNonTransactionalPutOperatorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015 DataTorrent, Inc. ALL Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.contrib.aerospike;
+
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.List;
+
+import com.datatorrent.contrib.aerospike.AerospikeTestUtils.TestPOJO;
+
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.NUM_TUPLES;
+
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.cleanTable;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getEvents;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getExpressions;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getNumOfEventsInStore;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getOperatorContext;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getStore;
+
+/**
+ * Tests {@link AerospikeNonTransactionalPutOperator}
+ */
+public class AerospikeNonTransactionalPutOperatorTest {
+
+  private static final String APP_ID = "AerospikeNonTransactionalPutOperatorTest";
+
+  @Test
+  public void TestAerospikeNonTransactionalPutOperator() {
+
+    cleanTable();
+
+    AerospikeNonTransactionalPutOperator outputOperator = new AerospikeNonTransactionalPutOperator();
+    outputOperator.setStore(getStore());
+    outputOperator.setExpressions(getExpressions());
+    outputOperator.setup(getOperatorContext(APP_ID));
+
+    List<TestPOJO> events = getEvents();
+
+    outputOperator.beginWindow(0);
+    for (TestPOJO event : events) {
+      outputOperator.input.process(event);
+    }
+    outputOperator.endWindow();
+
+    Assert.assertEquals("rows in db", NUM_TUPLES, getNumOfEventsInStore());
+  }
+
+}

--- a/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeNonTransactionalPutOperatorTest.java
+++ b/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeNonTransactionalPutOperatorTest.java
@@ -21,14 +21,13 @@ import java.util.List;
 
 import com.datatorrent.contrib.aerospike.AerospikeTestUtils.TestPOJO;
 
-import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.NUM_TUPLES;
-
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.checkEvents;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.cleanTable;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getEvents;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getExpressions;
-import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getNumOfEventsInStore;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getOperatorContext;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getStore;
+
 
 /**
  * Tests {@link AerospikeNonTransactionalPutOperator}
@@ -55,7 +54,8 @@ public class AerospikeNonTransactionalPutOperatorTest {
     }
     outputOperator.endWindow();
 
-    Assert.assertEquals("rows in db", NUM_TUPLES, getNumOfEventsInStore());
+    // check records
+    Assert.assertTrue("key and value check", checkEvents());
   }
 
 }

--- a/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeOperatorTest.java
+++ b/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeOperatorTest.java
@@ -20,10 +20,7 @@ import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Bin;
 import com.aerospike.client.Key;
 import com.aerospike.client.Record;
-import com.aerospike.client.query.RecordSet;
 import com.aerospike.client.query.Statement;
-import com.datatorrent.api.Attribute.AttributeMap;
-import com.datatorrent.api.DAG;
 import com.datatorrent.lib.helper.OperatorContextTestHelper;
 import com.datatorrent.lib.testbench.CollectorTestSink;
 import org.junit.Assert;
@@ -35,13 +32,11 @@ import java.util.List;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.NAMESPACE;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.NODE;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.NUM_TUPLES;
-import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.OPERATOR_ID;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.PORT;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.SET_NAME;
 
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.cleanTable;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.cleanMetaTable;
-import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getEvents;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getNumOfEventsInStore;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getOperatorContext;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getTransactionalStore;
@@ -89,7 +84,7 @@ public class AerospikeOperatorTest {
     @Override
     public TestEvent getTuple(Record record) {
 
-      return new TestEvent((Integer) record.getValue("ID"));
+      return new TestEvent(record.getInt("ID"));
     }
 
     @Override
@@ -104,8 +99,9 @@ public class AerospikeOperatorTest {
 
     public void insertEventsInTable(int numEvents) {
 
+      AerospikeClient client = null;
       try {
-        AerospikeClient client = new AerospikeClient(NODE, PORT);
+        client = new AerospikeClient(NODE, PORT);
         Key key;
         Bin bin;
         for (int i = 0; i < numEvents; i++) {
@@ -115,7 +111,10 @@ public class AerospikeOperatorTest {
         }
       }
       catch (AerospikeException e) {
-        throw new RuntimeException(e);
+        throw e;
+      }
+      finally {
+        if (null != client) client.close();
       }
     }
 

--- a/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeOperatorTest.java
+++ b/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeOperatorTest.java
@@ -15,7 +15,6 @@
  */
 package com.datatorrent.contrib.aerospike;
 
-
 import com.aerospike.client.AerospikeClient;
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Bin;
@@ -27,23 +26,33 @@ import com.datatorrent.api.Attribute.AttributeMap;
 import com.datatorrent.api.DAG;
 import com.datatorrent.lib.helper.OperatorContextTestHelper;
 import com.datatorrent.lib.testbench.CollectorTestSink;
-import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.ArrayList;
 import java.util.List;
+
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.NAMESPACE;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.NODE;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.NUM_TUPLES;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.OPERATOR_ID;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.PORT;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.SET_NAME;
+
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.cleanTable;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.cleanMetaTable;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getEvents;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getNumOfEventsInStore;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getOperatorContext;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getTransactionalStore;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getStore;
 
 /**
  * Tests for {@link AbstractAerosipkeTransactionalPutOperator} and {@link AbstractAerospikeGetOperator}
  */
 public class AerospikeOperatorTest {
 
-  public static final String NODE = "127.0.0.1";
-  public static final String NAMESPACE = "test";
-  public static final int PORT = 3000;
-
-  private static final String SET_NAME = "test_event_set";
   private static String APP_ID = "AerospikeOperatorTest";
-  private static int OPERATOR_ID = 0;
 
   private static class TestEvent {
 
@@ -54,54 +63,17 @@ public class AerospikeOperatorTest {
     }
   }
 
-  private static void cleanTable() {
-
-    try {
-      AerospikeClient client = new AerospikeClient(NODE, PORT);
-
-      Statement stmnt = new Statement();
-      stmnt.setNamespace(NAMESPACE);
-      stmnt.setSetName(SET_NAME);
-
-      RecordSet rs = client.query(null, stmnt);
-      while(rs.next()){
-        client.delete(null, rs.getKey());
-      }
-    }
-    catch (AerospikeException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-
   private static class TestOutputOperator extends AbstractAerospikeTransactionalPutOperator<TestEvent> {
 
     TestOutputOperator() {
       cleanTable();
-    }
-
-    public long getNumOfEventsInStore() {
-      try {
-        int count =0;
-        AerospikeClient client = new AerospikeClient(NODE, PORT);
-        Statement stmnt = new Statement();
-        stmnt.setNamespace(NAMESPACE);
-        stmnt.setSetName(SET_NAME);
-
-        RecordSet rs = client.query(null, stmnt);
-        while(rs.next()){
-          count++;
-        }
-        return count;
-      }
-      catch (AerospikeException e) {
-        throw new RuntimeException("fetching count", e);
-      }
+      cleanMetaTable();
     }
 
     @Override
     protected Key getUpdatedBins(TestEvent tuple, List<Bin> bins)
         throws AerospikeException {
+
       Key key = new Key(NAMESPACE,SET_NAME,String.valueOf(tuple.id));
       bins.add(new Bin("ID",tuple.id));
       return key;
@@ -152,23 +124,15 @@ public class AerospikeOperatorTest {
   @Test
   public void TestAerospikeOutputOperator() {
 
-    AerospikeTransactionalStore transactionalStore = new AerospikeTransactionalStore();
-    transactionalStore.setNode(NODE);
-    transactionalStore.setPort(PORT);
-    transactionalStore.setNamespace(NAMESPACE);
-
-    AttributeMap.DefaultAttributeMap attributeMap = new AttributeMap.DefaultAttributeMap();
-    attributeMap.put(DAG.APPLICATION_ID, APP_ID);
-    OperatorContextTestHelper.TestIdOperatorContext context = new OperatorContextTestHelper.TestIdOperatorContext(OPERATOR_ID, attributeMap);
-
+    AerospikeTransactionalStore transactionalStore = getTransactionalStore();
+    OperatorContextTestHelper.TestIdOperatorContext context = getOperatorContext(APP_ID);
     TestOutputOperator outputOperator = new TestOutputOperator();
 
     outputOperator.setStore(transactionalStore);
-
     outputOperator.setup(context);
 
-    List<TestEvent> events = Lists.newArrayList();
-    for (int i = 0; i < 10; i++) {
+    List<TestEvent> events = new ArrayList<TestEvent>();
+    for (int i = 0; i < NUM_TUPLES; i++) {
       events.add(new TestEvent(i));
     }
 
@@ -178,23 +142,18 @@ public class AerospikeOperatorTest {
     }
     outputOperator.endWindow();
 
-    Assert.assertEquals("rows in db", 10, outputOperator.getNumOfEventsInStore());
+    Assert.assertEquals("rows in db", NUM_TUPLES, getNumOfEventsInStore());
   }
 
   @Test
   public void TestAerospikeInputOperator() {
 
-    AerospikeStore store = new AerospikeStore();
-    store.setNode(NODE);
-    store.setPort(PORT);
-
-    AttributeMap.DefaultAttributeMap attributeMap = new AttributeMap.DefaultAttributeMap();
-    attributeMap.put(DAG.APPLICATION_ID, APP_ID);
-    OperatorContextTestHelper.TestIdOperatorContext context = new OperatorContextTestHelper.TestIdOperatorContext(OPERATOR_ID, attributeMap);
-
+    AerospikeStore store = getStore();
+    OperatorContextTestHelper.TestIdOperatorContext context = getOperatorContext(APP_ID);
     TestInputOperator inputOperator = new TestInputOperator();
+
     inputOperator.setStore(store);
-    inputOperator.insertEventsInTable(10);
+    inputOperator.insertEventsInTable(NUM_TUPLES);
 
     CollectorTestSink<Object> sink = new CollectorTestSink<Object>();
     inputOperator.outputPort.setSink(sink);
@@ -204,7 +163,7 @@ public class AerospikeOperatorTest {
     inputOperator.emitTuples();
     inputOperator.endWindow();
 
-    Assert.assertEquals("rows from db", 10, sink.collectedTuples.size());
+    Assert.assertEquals("rows from db", NUM_TUPLES, sink.collectedTuples.size());
   }
 
 }

--- a/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeTestUtils.java
+++ b/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeTestUtils.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2014 DataTorrent, Inc. ALL Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.contrib.aerospike;
+
+import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.AerospikeException;
+import com.aerospike.client.Bin;
+import com.aerospike.client.Key;
+import com.aerospike.client.query.RecordSet;
+import com.aerospike.client.query.Statement;
+import com.datatorrent.api.Attribute.AttributeMap;
+import com.datatorrent.api.DAG;
+import com.datatorrent.lib.helper.OperatorContextTestHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class encapsulating code used by several tests
+ */
+public class AerospikeTestUtils {
+  //public static final String NODE = "127.0.0.1";
+  public static final String NODE = "192.168.2.171";    // revert before commit
+
+  public static final String NAMESPACE = "test";
+  public static final int PORT = 3000;
+
+  public static final String SET_NAME = "test_event_set";
+  public static final int OPERATOR_ID = 0;
+  public static final int NUM_TUPLES = 10;
+
+  // removes all records from set SET_NAME in namespace NAMESPACE
+  static void cleanTable() {
+
+    try {
+      AerospikeClient client = new AerospikeClient(NODE, PORT);
+
+      Statement stmnt = new Statement();
+      stmnt.setNamespace(NAMESPACE);
+      stmnt.setSetName(SET_NAME);
+
+      RecordSet rs = client.query(null, stmnt);
+      while(rs.next()){
+        client.delete(null, rs.getKey());
+      }
+    }
+    catch (AerospikeException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // removes all records from set AerospikeTransactionalStore.DEFAULT_META_SET (used to store
+  // committed window ids) in namespace NAMESPACE
+  //
+  static void cleanMetaTable() {
+
+    try {
+      AerospikeClient client = new AerospikeClient(NODE, PORT);
+
+      Statement stmnt = new Statement();
+      stmnt.setNamespace(NAMESPACE);
+      stmnt.setSetName(AerospikeTransactionalStore.DEFAULT_META_SET);
+
+      RecordSet rs = client.query(null, stmnt);
+      while(rs.next()){
+        client.delete(null, rs.getKey());
+      }
+    }
+    catch (AerospikeException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // returns the number of records in set SET_NAME in namespace NAMESPACE
+  static long getNumOfEventsInStore() {
+    try {
+      long count = 0;
+      AerospikeClient client = new AerospikeClient(NODE, PORT);
+      Statement stmnt = new Statement();
+      stmnt.setNamespace(NAMESPACE);
+      stmnt.setSetName(SET_NAME);
+
+      RecordSet rs = client.query(null, stmnt);
+      while(rs.next()){
+        count++;
+      }
+      return count;
+    }
+    catch (AerospikeException e) {
+      throw new RuntimeException("fetching count", e);
+    }
+  }
+
+  static AerospikeStore getStore()
+  {
+    AerospikeStore result = new AerospikeStore();
+    result.setNode(NODE);
+    result.setPort(PORT);
+    //result.setNamespace(NAMESPACE);    // add if needed
+    return result;
+  }
+
+  static AerospikeTransactionalStore getTransactionalStore()
+  {
+    AerospikeTransactionalStore result = new AerospikeTransactionalStore();
+    result.setNode(NODE);
+    result.setPort(PORT);
+    result.setNamespace(NAMESPACE);    // used by AerospikeTransactionalStore.createIndexes()
+    return result;
+  }
+
+  static OperatorContextTestHelper.TestIdOperatorContext getOperatorContext(final String app_id)
+  {
+    AttributeMap.DefaultAttributeMap attributeMap = new AttributeMap.DefaultAttributeMap();
+    attributeMap.put(DAG.APPLICATION_ID, app_id);
+    return new OperatorContextTestHelper.TestIdOperatorContext(OPERATOR_ID, attributeMap);
+  }
+
+  static ArrayList<String> getExpressions()
+  {
+    ArrayList<String> result = new ArrayList<String>();
+    result.add("getKey()");
+    result.add("getBins()");
+    return result;
+  }
+
+  static List<TestPOJO> getEvents()
+  {
+    List<TestPOJO> result = new ArrayList<TestPOJO>();
+    for (int i = 0; i < NUM_TUPLES; i++) {
+      result.add(new TestPOJO(i));
+    }
+    return result;
+  }
+
+  // needs to be public for PojoUtils to work
+  public static class TestPOJO {
+
+    int id;
+
+    TestPOJO(int id) {
+      this.id = id;
+    }
+
+    public Key getKey() {
+      try {
+        Key key = new Key(NAMESPACE, SET_NAME, String.valueOf(id));
+        return key;
+      }
+      catch (AerospikeException e) {
+        throw new RuntimeException("getKey failed: ", e);
+      }
+    }
+
+    public List<Bin> getBins() {
+      List<Bin> list = new ArrayList<Bin>();
+      list.add(new Bin("ID",id));
+      return list;
+    }
+  }
+
+}

--- a/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeTestUtils.java
+++ b/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeTestUtils.java
@@ -32,8 +32,7 @@ import java.util.List;
  * Utility class encapsulating code used by several tests
  */
 public class AerospikeTestUtils {
-  //public static final String NODE = "127.0.0.1";
-  public static final String NODE = "192.168.2.171";    // revert before commit
+  public static final String NODE = "127.0.0.1";
 
   public static final String NAMESPACE = "test";
   public static final int PORT = 3000;

--- a/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperatorTest.java
+++ b/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperatorTest.java
@@ -21,13 +21,11 @@ import java.util.List;
 
 import com.datatorrent.contrib.aerospike.AerospikeTestUtils.TestPOJO;
 
-import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.NUM_TUPLES;
-
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.checkEvents;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.cleanTable;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.cleanMetaTable;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getEvents;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getExpressions;
-import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getNumOfEventsInStore;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getOperatorContext;
 import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getTransactionalStore;
 
@@ -56,7 +54,8 @@ public class AerospikeTransactionalPutOperatorTest {
     }
     outputOperator.endWindow();
 
-    Assert.assertEquals("rows in db", NUM_TUPLES, getNumOfEventsInStore());
+    // check records
+    Assert.assertTrue("key and value check", checkEvents());
   }
 
 }

--- a/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperatorTest.java
+++ b/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperatorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015 DataTorrent, Inc. ALL Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.contrib.aerospike;
+
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.List;
+
+import com.datatorrent.contrib.aerospike.AerospikeTestUtils.TestPOJO;
+
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.NUM_TUPLES;
+
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.cleanTable;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.cleanMetaTable;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getEvents;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getExpressions;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getNumOfEventsInStore;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getOperatorContext;
+import static com.datatorrent.contrib.aerospike.AerospikeTestUtils.getTransactionalStore;
+
+/**
+ * Tests {@link AerospikeTransactionalPutOperator}
+ */
+public class AerospikeTransactionalPutOperatorTest {
+
+  private static final String APP_ID = "AerospikeTransactionalPutOperatorTest";
+
+  @Test
+  public void TestAerospikeTransactionalPutOperator() {
+
+    cleanTable(); cleanMetaTable();
+
+    AerospikeTransactionalPutOperator outputOperator = new AerospikeTransactionalPutOperator();
+    outputOperator.setStore(getTransactionalStore());
+    outputOperator.setExpressions(getExpressions());
+    outputOperator.setup(getOperatorContext(APP_ID));
+
+    List<TestPOJO> events = getEvents();
+
+    outputOperator.beginWindow(0);
+    for (TestPOJO event : events) {
+      outputOperator.input.process(event);
+      System.out.println("Processed event");
+    }
+    outputOperator.endWindow();
+
+    Assert.assertEquals("rows in db", NUM_TUPLES, getNumOfEventsInStore());
+  }
+
+}

--- a/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperatorTest.java
+++ b/contrib/src/test/java/com/datatorrent/contrib/aerospike/AerospikeTransactionalPutOperatorTest.java
@@ -53,7 +53,6 @@ public class AerospikeTransactionalPutOperatorTest {
     outputOperator.beginWindow(0);
     for (TestPOJO event : events) {
       outputOperator.input.process(event);
-      System.out.println("Processed event");
     }
     outputOperator.endWindow();
 

--- a/demos/dimensions/pom.xml
+++ b/demos/dimensions/pom.xml
@@ -355,11 +355,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.aerospike</groupId>
-      <artifactId>aerospike-client</artifactId>
-      <version>3.0.35</version>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>malhar-contrib</artifactId>
       <version>${datatorrent.version}</version>

--- a/demos/dimensions/pom.xml
+++ b/demos/dimensions/pom.xml
@@ -357,7 +357,7 @@
     <dependency>
       <groupId>com.aerospike</groupId>
       <artifactId>aerospike-client</artifactId>
-      <version>3.0.26</version>
+      <version>3.0.35</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/demos/dimensions/pom.xml
+++ b/demos/dimensions/pom.xml
@@ -355,6 +355,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.aerospike</groupId>
+      <artifactId>aerospike-client</artifactId>
+      <version>3.0.26</version>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>malhar-contrib</artifactId>
       <version>${datatorrent.version}</version>


### PR DESCRIPTION
Added concrete operators for transactional and non-transactional output operators for aerospike
as well as tests; refactored tests to reduce code duplication; some code cleanup.
