### PR TITLE
SPOI-5193: Fix NPE in recovery.

### DIFF
--- a/contrib/src/main/java/com/datatorrent/contrib/hdht/HDHTReader.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/hdht/HDHTReader.java
@@ -346,6 +346,7 @@ public class HDHTReader implements Operator, HDHT.Reader
     protected BucketMeta(Comparator<Slice> cmp)
     {
       files = new TreeMap<Slice, BucketFileMeta>(cmp);
+      recoveryStartWalPosition = new HDHTWalManager.WalPosition(0, 0);
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
When no META file is present we create a new instance of BucketMeta which has recoveryStartWalPosition set to NULL which is used during recovery causing NPE.
The fix is to initialize recoveryStartWalPosition in constructor.