### PR TITLE
MLHR-1758 moved RubyOperator to contrib because of transitive depende…

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -659,5 +659,11 @@
       <version>1.0</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby</artifactId>
+      <version>1.7.12</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/contrib/src/main/java/com/datatorrent/contrib/ruby/RubyOperator.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/ruby/RubyOperator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datatorrent.lib.script;
+package com.datatorrent.contrib.ruby;
 
 import java.util.Map;
 
@@ -26,6 +26,11 @@ import com.datatorrent.api.Context.OperatorContext;
 /**
  * An implementation of ScriptOperator that executes ruby script on tuples
  * <p>
+ *
+ * WARNING: EXPERIMENTAL USE ONLY!  This operator depends on jruby which has
+ * a transitive dependency on an incompatible version of ASM that breaks 
+ * webservice in stram.
+ *
  * @displayName Ruby Operator
  * @category Scripting
  * @tags script operator, map, string

--- a/contrib/src/test/java/com/datatorrent/contrib/ruby/RubyOperatorTest.java
+++ b/contrib/src/test/java/com/datatorrent/contrib/ruby/RubyOperatorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datatorrent.lib.script;
+package com.datatorrent.contrib.ruby;
 
 import com.datatorrent.lib.testbench.CollectorTestSink;
 

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -304,11 +304,6 @@
       <version>3.2</version>
     </dependency>
     <dependency>
-      <groupId>org.jruby</groupId>
-      <artifactId>jruby</artifactId>
-      <version>1.7.12</version>
-    </dependency>
-    <dependency>
       <groupId>com.github.tony19</groupId>
       <artifactId>named-regexp</artifactId>
       <version>0.2.3</version>


### PR DESCRIPTION
…ncy that can break stram webservice