### PR TITLE
Fix removal of vagrant tmp files when output file is in subdirectory …

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/io/fs/AbstractFileOutputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/io/fs/AbstractFileOutputOperator.java
@@ -1139,10 +1139,10 @@ public abstract class AbstractFileOutputOperator<INPUT> extends BaseOperator imp
     fileNameToTmpName.remove(fileName);
 
     //when writing to tmp files there can be vagrant tmp files which we have to clean
-    FileStatus[] statuses = fs.listStatus(new Path(filePath));
+    FileStatus[] statuses = fs.listStatus(destPath.getParent());
     for (FileStatus status : statuses) {
       String statusName = status.getPath().getName();
-      if (statusName.endsWith(TMP_EXTENSION) && statusName.startsWith(fileName)) {
+      if (statusName.endsWith(TMP_EXTENSION) && statusName.startsWith(destPath.getName())) {
         LOG.debug("deleting vagrant file {}", statusName);
         fs.delete(status.getPath(), true);
       }


### PR DESCRIPTION
This pull request adds removal of left-over tmp files for output files that may be located in a subdirectory of the writer's filePath.  The use case is a single writer that outputs to multiple files using a file naming scheme that includes directory components.  With this change, the writer removes the matching tmp files that have the same parent directory as the output file being finalized.